### PR TITLE
Add basic CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const jsonSum = require('../dist/json-summary-node');
+const { version, name } = require('../package');
+const STDIN = process.stdin.fd;
+const scriptName = path.basename(process.argv[1]);
+
+if (process.argv.includes('-v')) {
+  console.error(`${name} v${version}`);
+  process.exit(0);
+}
+
+const fn = process.argv[2];
+if (!fn || fn.startsWith('--')) {
+  console.error(`Usage:  ${scriptName} <file.json|- (stdin)>  [--indent N]`);
+  process.exit(1);
+}
+
+let data;
+if (fn === '-') {  // read from stdin
+  data = fs.readFileSync(STDIN, 'utf-8');
+  data = JSON.parse(data);
+} else {
+  data = require(path.resolve(fn));
+}
+
+let indent = process.argv.indexOf('--indent');
+if (indent !== -1) {
+  indent = parseInt(process.argv[indent + 1]);
+}
+
+let summary = jsonSum.summarize(data);
+
+let text = jsonSum.printSummary(summary, {
+  asText: true,
+  ...(indent >= 0 ? {
+    indentCount: indent
+  } : null)
+});
+
+console.log(text);
+process.exit(0);

--- a/docs/index.html
+++ b/docs/index.html
@@ -232,7 +232,7 @@
           </tr>
           <tr>
             <td style="font-family: 'Courier New', Courier, monospace;">
-              identCount
+              indentCount
             </td>
             <td style="font-family: 'Courier New', Courier, monospace;">
               Number

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "summary"
   ],
   "main": "dist/json-summary-node.js",
+  "bin": "bin/cli.js",
   "module": "index.js",
   "browser": "dist/json-summary.js",
   "browserMin": "dist/json-summary.min.js",
   "files": [
     "/dist",
+    "/bin",
     "index.js"
   ],
   "scripts": {


### PR DESCRIPTION
I find CLI commands very useful.
```
$ bin/cli.js package.json
{
   name: <string>,
   version: <string>,
   description: <string>,
   keywords: (4) [<string>],
   main: <string>,
   bin: <string>,
   module: <string>,
   browser: <string>,
   browserMin: <string>,
   files: (3) [<string>],
   scripts: {
     lint: <string>,
...
```
or as pipe: `$ cat foo.json | json-summary -`.  (When installed with `-g` the name of the binary is the same as the package name.

